### PR TITLE
add-menu-icons-tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexae/design-tokens",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "Comète",
   "type": "module",
   "files": [

--- a/tokens/components/tokens.json
+++ b/tokens/components/tokens.json
@@ -7185,6 +7185,35 @@
               "$value": "{background.disabled.default}"
             }
           }
+        },
+        "icon": {
+          "selected": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ]
+            },
+            "$type": "color",
+            "$value": "{icon.selected}"
+          },
+          "default": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ]
+            },
+            "$type": "color",
+            "$value": "{icon.default}"
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.scopes": [
+                "ALL_SCOPES"
+              ]
+            },
+            "$type": "color",
+            "$value": "{icon.disabled}"
+          }
         }
       },
       "text": {


### PR DESCRIPTION
Ajout des tokens de couleur pour les icônes du menu (manquants).

Pas d'intégration attendue dans l'immédiat -> pas de nouveau TGZ